### PR TITLE
Remove costly loops

### DIFF
--- a/Math/DecimalMath/DecimalMath.cs
+++ b/Math/DecimalMath/DecimalMath.cs
@@ -76,16 +76,19 @@
             public static decimal Exp(decimal x)
             {
                 var count = 0;
-                while (x > One)
+
+                if (x > One)
                 {
-                    x--;
-                    count++;
+                    count = Decimal.ToInt32(Decimal.Truncate(x));
+                    x = 0m + (x - Decimal.Truncate(x));
                 }
-                while (x < Zero)
+
+                if (x < Zero)
                 {
-                    x++;
-                    count--;
+                    count = Decimal.ToInt32(Decimal.Truncate(x) - 1);
+                    x = 1.0m + (x - Decimal.Truncate(x));
                 }
+
                 var iteration = 1;
                 var result = One;
                 var fatorial = One;


### PR DESCRIPTION
In this PR:
 - Removed costly loops from the Exp. This significantly increases performance when raising _e_ to large decimal exponents

* Note - probably worth changing Int32 to Int64 for counters in this method.